### PR TITLE
feat: クライアントからBEへリクエストせずに中間APIを噛ませる (#39)

### DIFF
--- a/src/components/transfer/AccountDropdown.tsx
+++ b/src/components/transfer/AccountDropdown.tsx
@@ -21,9 +21,6 @@ const AccountDropdown: NextPage<Props> = ({
   transfer,
   column,
 }) => {
-  const { data: session } = useSession();
-  const token = session?.accessToken as string;
-
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const toggle = () => setDropdownOpen((prevState) => !prevState);
 
@@ -37,9 +34,9 @@ const AccountDropdown: NextPage<Props> = ({
     setTitle(newTitle);
     const newTransfer = { ...transfer, [column]: newAccountId };
     if (transfer.type === 'temporary') {
-      await updateTemporary(token, newTransfer as TemporaryTransfer);
+      await updateTemporary(newTransfer as TemporaryTransfer);
     } else if (transfer.type === 'regular') {
-      await updateRegular(token, newTransfer as RegularTransfer);
+      await updateRegular(newTransfer as RegularTransfer);
     }
   };
 

--- a/src/components/transfer/RegularTransferTable.tsx
+++ b/src/components/transfer/RegularTransferTable.tsx
@@ -1,6 +1,7 @@
 import { NextPage } from 'next';
 import { Table } from 'reactstrap';
 import AccountDropdown from './AccountDropdown';
+import { useState } from 'react';
 
 interface Props {
   regularList: RegularTransfer[];
@@ -11,6 +12,58 @@ const RegularTransferTable: NextPage<Props> = ({
   regularList,
   accountList,
 }) => {
+  const [updatedRegularList, setUpdatedRegularList] =
+    useState<RegularTransfer[]>(regularList);
+  const transferProperties: Array<keyof RegularTransfer> = [
+    'fromAccountName',
+    'toAccountName',
+    'description',
+    'amount',
+    'ratio',
+  ];
+
+  const onChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    changedRegular: RegularTransfer
+  ) => {
+    const property = e.target.name as keyof RegularTransfer;
+    const changeId = changedRegular.id;
+
+    // 表示してるregularListを更新 and 変更のあるregularをisChange:true
+    setUpdatedRegularList(
+      updatedRegularList.map((regular) => {
+        let isChanged = false;
+        if (regular.id === changeId) {
+          for (const p of transferProperties) {
+            if (p === property) {
+              if (
+                e.target.value !==
+                regularList.filter((reg) => reg.id === changeId)[0][p]
+              ) {
+                isChanged = true;
+                break;
+              }
+            } else {
+              if (
+                regular[p] !==
+                regularList.filter((reg) => reg.id === changeId)[0][p]
+              ) {
+                isChanged = true;
+                break;
+              }
+            }
+          }
+          return {
+            ...regular,
+            [property]: e.target.value,
+            isChanged: isChanged,
+          };
+        }
+        return regular;
+      })
+    );
+  };
+
   return (
     <div>
       <Table hover>
@@ -24,7 +77,7 @@ const RegularTransferTable: NextPage<Props> = ({
           </tr>
         </thead>
         <tbody>
-          {regularList.map((regular) => (
+          {updatedRegularList.map((regular) => (
             <tr key={regular.id}>
               <td>
                 <AccountDropdown
@@ -40,7 +93,20 @@ const RegularTransferTable: NextPage<Props> = ({
                   column="toAccount"
                 />
               </td>
-              <td>{regular.description}</td>
+              <td>
+                <input
+                  type="text"
+                  style={{
+                    border: 'none',
+                    outline: 'none',
+                    backgroundColor: '#FFF',
+                    padding: '5px',
+                  }}
+                  name="description"
+                  value={regular.description}
+                  onChange={(e) => onChange(e, regular)}
+                />
+              </td>
               {regular.percentage == false ? (
                 <td>{regular.amount}</td>
               ) : (
@@ -52,6 +118,7 @@ const RegularTransferTable: NextPage<Props> = ({
               ) : (
                 <td>-</td>
               )}
+              <td>{regular.isChanged ? 'change!' : 'not'}</td>
             </tr>
           ))}
         </tbody>

--- a/src/lib/regularReq.ts
+++ b/src/lib/regularReq.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { headers } from 'next/dist/client/components/headers';
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
@@ -9,28 +10,23 @@ export const findRegular = async (token: string) => {
     },
   });
   const regularList: RegularTransfer[] = res.data;
-  const regularListWithType: RegularTransfer[] = regularList.map((regular) => {
+  const regularListEx: RegularTransfer[] = regularList.map((regular) => {
     return {
       ...regular,
       type: 'regular',
+      isChanged: false,
     };
   });
-  return regularListWithType;
+  return regularListEx;
 };
 
 export const updateRegular = async (
-  token: string,
   regular: RegularTransfer
 ) => {
   try {
-    await axios.patch(`${apiUrl}/api/regular`, regular, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-    });
-    console.log('update regular success');
+    await axios.post('/api/regular/update', regular);
+    console.log('Success to update RegularTransfer');
   } catch (error) {
-    console.error('update regular error');
+    console.log('Failed to update RegularTransfer');
   }
 };

--- a/src/lib/temporaryReq.ts
+++ b/src/lib/temporaryReq.ts
@@ -9,31 +9,24 @@ export const findTemporary = async (token: string) => {
     },
   });
   const temporaryList: TemporaryTransfer[] = res.data;
-  const temporaryListWithType: TemporaryTransfer[] = temporaryList.map(
+  const temporaryListEx: TemporaryTransfer[] = temporaryList.map(
     (temporary): TemporaryTransfer => {
       return {
         ...temporary,
         type: 'temporary',
+        isChanged: false,
       };
     }
   );
 
-  return temporaryListWithType;
+  return temporaryListEx;
 };
 
-export const updateTemporary = async (
-  token: string,
-  temporary: TemporaryTransfer
-) => {
+export const updateTemporary = async (temporary: TemporaryTransfer) => {
   try {
-    await axios.patch(`${apiUrl}/api/temporary`, temporary, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-    });
-    console.log('update temporary success');
+    await axios.post('/api/temporary/update', temporary);
+    console.log('Success to update TemporaryTransfer');
   } catch {
-    console.error('update temporary error');
+    console.error('Failed to update TemporaryTransfer');
   }
 };

--- a/src/pages/api/regular/update.ts
+++ b/src/pages/api/regular/update.ts
@@ -1,0 +1,33 @@
+import { isTokenExpired } from '@/lib/ JwtUtils';
+import axios from 'axios';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getToken } from 'next-auth/jwt';
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const user = await getToken({ req });
+  const token = user?.accessToken;
+
+  if (!token || isTokenExpired(token)) {
+    return res.status(401).json({ error: '認証が必要です' });
+  }
+
+  let apiRes;
+  try {
+    apiRes = await axios.patch(`${apiUrl}/api/regular`, req.body, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      withCredentials: true,
+    });
+
+    return res.status(apiRes.status).json(apiRes.data);
+  } catch (error) {
+    console.log('Failed to update RegularTransfer');
+    return res.status(401).json({ error: '認証が必要です' });
+  }
+}

--- a/src/pages/api/temporary/update.ts
+++ b/src/pages/api/temporary/update.ts
@@ -1,0 +1,33 @@
+import { isTokenExpired } from '@/lib/ JwtUtils';
+import axios from 'axios';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getToken } from 'next-auth/jwt';
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const user = await getToken({ req });
+  const token = user?.accessToken;
+
+  if (!token || isTokenExpired(token)) {
+    return res.status(401).json({ error: '認証が必要です' });
+  }
+
+  let apiRes;
+  try {
+    apiRes = await axios.patch(`${apiUrl}/api/temporary`, req.body, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      withCredentials: true,
+    });
+
+    return res.status(apiRes.status).json(apiRes.data);
+  } catch (error) {
+    console.log('Failed to update RegularTransfer');
+    return res.status(401).json({ error: '認証が必要です' });
+  }
+}

--- a/src/types/RegularTransfer.ts
+++ b/src/types/RegularTransfer.ts
@@ -10,4 +10,5 @@ type RegularTransfer = {
   ratio?: number;
   userId: number;
   type: 'regular';
+  isChanged?: boolean;
 };

--- a/src/types/TemporaryTransfer.ts
+++ b/src/types/TemporaryTransfer.ts
@@ -9,4 +9,5 @@ type TemporaryTransfer = {
   userId: number;
   transferId: number;
   type: 'temporary';
+  isChanged?: boolean;
 };


### PR DESCRIPTION
* feat: jwtの有効期限チェック

* feat:有効期限チェック処理

* feat: isChanged追加

* feat: isChangedのデフォルト値追加

* feat: 各regularが変化したかどうかのチェック処理

* feat: regular, temporaryのupdate API作成

* feat: 中間APIからBEへリクエスト

* refactor: 不要になったtokenの記述を削除